### PR TITLE
feat: default to today or nearest upcoming date in activity section

### DIFF
--- a/src/components/page-section/activity-section.tsx
+++ b/src/components/page-section/activity-section.tsx
@@ -43,7 +43,37 @@ export default function ActivitySection() {
       setEventsByDate(eventsByDate);
       const dates = sortEventsByDate(Object.keys(eventsByDate));
       setTotalPages(dates.length);
-      setCurrentPage(0);
+
+      // Find today or nearest upcoming date
+      const today = new Date();
+      today.setHours(0, 0, 0, 0); // Reset time to start of day for accurate comparison
+
+      let defaultPageIndex = 0;
+
+      // First, try to find today's date
+      const todayIndex = dates.findIndex(date => {
+        const eventDate = new Date(date);
+        eventDate.setHours(0, 0, 0, 0);
+        return eventDate.getTime() === today.getTime();
+      });
+
+      if (todayIndex !== -1) {
+        defaultPageIndex = todayIndex;
+      } else {
+        // If today is not found, find the nearest upcoming date
+        const upcomingIndex = dates.findIndex(date => {
+          const eventDate = new Date(date);
+          eventDate.setHours(0, 0, 0, 0);
+          return eventDate.getTime() >= today.getTime();
+        });
+
+        if (upcomingIndex !== -1) {
+          defaultPageIndex = upcomingIndex;
+        }
+        // If no upcoming dates, defaultPageIndex remains 0 (first event)
+      }
+
+      setCurrentPage(defaultPageIndex);
       setDates(dates);
     }
     fetchEvents();


### PR DESCRIPTION
Previously, the activity section defaulted to showing the first event chronologically. Now it defaults to today's events if available, or the nearest upcoming events, providing a more relevant user experience.

🤖 Generated with [Claude Code](https://claude.ai/code)

## 🚀 PR Motivation

<!-- Briefly describe the purpose and background of this PR (e.g., bug fix, new feature, refactor, documentation update, etc.) -->
-

---

## 📝 Summary of Changes

<!-- List the main changes in this PR -->
-

---

## 🧪 Test Plan

- [ ] Local tests passed
- [ ] Unit tests passed
- [ ] CI/CD checks passed
- Additional test notes:

---

## 📚 Related Documents

<!-- Link to design docs, issues, PRD, mockups, screenshots, etc. -->
-

---

## ⚠️ Impact

- [ ] Frontend only
- [ ] Backend only
- [ ] API changes
- [ ] Database changes
- [ ] Other (please specify):

---

## 👀 Reviewer Checklist

- [ ] Code style follows project conventions
- [ ] Changes are well-commented
- [ ] No unused code or comments
- [ ] Sufficient test coverage
- [ ] Documentation updated (if needed)

---

## Notes

<!-- Any additional notes for reviewers -->
-
