### PR TITLE
fix(calendar): Fix navigation button positioning for react-day-picker v9

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -18,25 +18,30 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row gap-2",
+        months: "relative flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
         month_caption: "flex justify-center pt-1 relative items-center w-full",
         caption_label: "text-sm font-medium",
-        nav: "flex items-center gap-1",
+        nav: "flex items-center gap-1 absolute top-0 w-full justify-between z-10",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "absolute left-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "absolute right-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
         ),
         month_grid: "w-full border-collapse space-x-1",
         weekdays: "flex",
         weekday:
           "text-neutral-500 rounded-md w-8 font-normal text-[0.8rem] dark:text-neutral-400",
         week: "flex w-full mt-2",
-        day: "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-neutral-100 [&:has([aria-selected].day-range-end)]:rounded-r-md dark:[&:has([aria-selected])]:bg-neutral-800 [&:has([aria-selected])]:rounded-md",
+        day: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-neutral-100 [&:has([aria-selected].day-range-end)]:rounded-r-md dark:[&:has([aria-selected])]:bg-neutral-800",
+          props.mode === "range"
+            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            : "[&:has([aria-selected])]:rounded-md"
+        ),
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
           "size-8 p-0 font-normal aria-selected:opacity-100"
@@ -57,9 +62,9 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Chevron: ({ orientation, className, ...props }) => {
+        Chevron: ({ orientation }) => {
           const Icon = orientation === "left" ? ChevronLeft : ChevronRight
-          return <Icon className={cn("size-4", className)} {...props} />
+          return <Icon className="size-4" />
         },
       }}
       {...props}


### PR DESCRIPTION
- Add `relative` positioning to months container for proper nav button placement
- Update nav styles to use `absolute top-0 w-full justify-between` for correct layout
- Remove redundant absolute positioning from individual nav buttons
- Add range mode support for day cell styling

The navigation arrows were not visible because the nav container lacked proper positioning context. This fix ensures the < > buttons display correctly on either side of the month name.

## 🚀 PR Motivation

<!-- Briefly describe the purpose and background of this PR (e.g., bug fix, new feature, refactor, documentation update, etc.) -->
-

---

## 📝 Summary of Changes

<!-- List the main changes in this PR -->
-

---

## 🧪 Test Plan

- [ ] Local tests passed
- [ ] Unit tests passed
- [ ] CI/CD checks passed
- Additional test notes:

---

## 📚 Related Documents

<!-- Link to design docs, issues, PRD, mockups, screenshots, etc. -->
-

---

## ⚠️ Impact

- [ ] Frontend only
- [ ] Backend only
- [ ] API changes
- [ ] Database changes
- [ ] Other (please specify):

---

## 👀 Reviewer Checklist

- [ ] Code style follows project conventions
- [ ] Changes are well-commented
- [ ] No unused code or comments
- [ ] Sufficient test coverage
- [ ] Documentation updated (if needed)

---

## Notes

<!-- Any additional notes for reviewers -->
-
