### PR TITLE
ci: skip Firebase deploy for Dependabot PRs and fix branch name

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -7,7 +7,7 @@ name: Dependabot PR Check
 
 on:
   pull_request_target:
-    branches: ["master"]
+    branches: ["main"]
 
 permissions:
   contents: write

--- a/.github/workflows/firebase-hosting-test.yml
+++ b/.github/workflows/firebase-hosting-test.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Skip `build_and_deploy` job in `firebase-hosting-test.yml` when the PR actor is `dependabot[bot]` to avoid unnecessary staging deploys
- Fix `dependabot-pr-check.yml` trigger branch from `master` to `main`

## Test plan
- [ ] Verify Dependabot PRs no longer trigger Firebase staging deploys
- [ ] Verify non-Dependabot PRs still trigger Firebase staging deploys as expected
- [ ] Verify Dependabot PRs still trigger the `dependabot-pr-check` workflow on the `main` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)