### PR TITLE
ci: add rebase-strategy auto to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "auto"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    rebase-strategy: "auto"


### PR DESCRIPTION
## Summary
- Add `rebase-strategy: "auto"` to both `npm` and `github-actions` ecosystems in `dependabot.yml`
- Ensures Dependabot automatically rebases its PRs against `main` when conflicts arise

## Test plan
- [ ] Verify existing Dependabot PRs rebase automatically after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)