### PR TITLE
fix(ci): add --legacy-peer-deps to dependabot-pr-check install step

### DIFF
--- a/.github/workflows/dependabot-pr-check.yml
+++ b/.github/workflows/dependabot-pr-check.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('src/package-lock.json', 'src/yarn.lock') }}-
 
       - name: Install dependencies
-        run: cd src && ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+        run: cd src && ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }} --legacy-peer-deps
 
       - name: Run lint
         run: cd src && npm run lint


### PR DESCRIPTION
## Summary
- Add `--legacy-peer-deps` to the `Install dependencies` step in `dependabot-pr-check.yml`
- Fixes `ERESOLVE` peer dependency conflicts (e.g. `typescript@6` vs `i18next` expecting `^5`)
- Matches the `--legacy-peer-deps` flag already used in all other workflows

## Root cause
PR [#41](https://github.com/gdg-twhk/gdg-taiwan-React/pull/41) (TypeScript 5→6 bump) caused `npm install` to fail with a peer dependency conflict. The dependabot-pr-check workflow was the only one not using `--legacy-peer-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)