### PR TITLE
ci: increase Dependabot open-pull-requests-limit to 100

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
     directory: "/src"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
     rebase-strategy: "auto"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 100
     rebase-strategy: "auto"


### PR DESCRIPTION
## Summary
- Bumps `open-pull-requests-limit` from `10` to `100` for both `npm` and `github-actions` ecosystems
- Prevents Dependabot from silently skipping newer updates when the PR queue is full

🤖 Generated with [Claude Code](https://claude.com/claude-code)