### PR TITLE
fix(lint): migrate from next lint to ESLint CLI for Next.js 16 compatibility

### DIFF
--- a/src/eslint.config.mjs
+++ b/src/eslint.config.mjs
@@ -10,6 +10,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  { ignores: ["next-env.d.ts"] },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 

--- a/src/helper/index.ts
+++ b/src/helper/index.ts
@@ -30,7 +30,7 @@ export const collectEventsByDate = (events: Event[]) : { [key: string]: Event[] 
     const startStr = getISODate(startDate);
     const endStr = getISODate(endDate);
     
-    let loopDate = new Date(startStr); // This creates a date at 00:00:00 UTC
+    const loopDate = new Date(startStr); // This creates a date at 00:00:00 UTC
     const lastDate = new Date(endStr);
     
     while (loopDate <= lastDate) {

--- a/src/package.json
+++ b/src/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "export": "next export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

- Change `npm run lint` script from `next lint` to `eslint .` — `next lint` is deprecated and removed in Next.js 16, causing a circular JSON serialization error in CI
- Ignore `next-env.d.ts` in ESLint config — this file is auto-generated by Next.js and contains a triple-slash reference that triggers `@typescript-eslint/triple-slash-reference`
- Fix `prefer-const` violation in `src/helper/index.ts:33` (`loopDate` is mutated but never reassigned)

## Why

Both Dependabot PRs #68 and #71 bump `next`/`eslint-config-next` to v16. The `next lint` command was removed in Next.js 16 and crashes with:
```
Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'react' closes the circle
```

Merging this PR first unblocks those Dependabot PRs (they will need a rebase after this lands).

## Test plan

- [x] `npm run lint` runs cleanly with zero errors locally (Next.js 15)
- [ ] After merge, comment `@dependabot rebase` on PR #68 and #71 to verify CI passes with Next.js 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)