### PR TITLE
feat(activity): remove international_womens_day and build_with_ai

### DIFF
--- a/src/components/site-desktop-menu.tsx
+++ b/src/components/site-desktop-menu.tsx
@@ -28,17 +28,11 @@ export function SiteDesktopMenu() {
         <NavigationMenuTrigger>{t('navigation.annualActivities')}</NavigationMenuTrigger>
           <NavigationMenuContent className="bg-card !absolute !top-full !left-0 !z-[9999] shadow-lg border !transform-none">
         <ul className="grid gap-3 p-6 md:w-[400px]">
-          <ListItem href="/annual_activity/international_womens_day" title={t('navigation.internationalWomensDay.title')}>
-            {t('navigation.internationalWomensDay.description')}
-          </ListItem>
           <ListItem href="/annual_activity/google_io_extended" title={t('navigation.googleIOExtended.title')}>
             {t('navigation.googleIOExtended.description')}
           </ListItem>
           <ListItem href="/annual_activity/cloud_study_jam" title={t('navigation.cloudStudyJam.title')}>
             {t('navigation.cloudStudyJam.description')}
-          </ListItem>
-          <ListItem href="/annual_activity/build_with_ai" title={t('navigation.buildWithAi.title')}>
-            {t('navigation.buildWithAi.description')}
           </ListItem>
           <ListItem href="/annual_activity/devfest" title={t('navigation.devfest.title')}>
             {t('navigation.devfest.description')}

--- a/src/components/site-mobile-menu.tsx
+++ b/src/components/site-mobile-menu.tsx
@@ -9,7 +9,7 @@ import { DrawerContent } from './ui/drawer';
 import { LanguageToggle } from './language-toggle';
 import { ModeToggle } from './model-toggle';
 import { useState, useEffect } from 'react';
-import { IconBrandGoogle, IconCalendarEvent, IconCode, IconCloud, IconMapPin, IconWomanFilled, IconHome, IconRobot } from '@tabler/icons-react';
+import { IconBrandGoogle, IconCalendarEvent, IconCode, IconCloud, IconMapPin, IconHome } from '@tabler/icons-react';
 
 export function SiteMobileMenu() {
   const { t } = useTranslation();
@@ -35,33 +35,21 @@ export function SiteMobileMenu() {
   }, [isAnyAnnualActivityActive]);
 
   const annualActivities = [
-    { 
-      icon: IconWomanFilled, 
-      label: t('navigation.internationalWomensDay.title'), 
-      href: '/annual_activity/international_womens_day',
-      isActive: isActive('/annual_activity/international_womens_day')
-    },
-    { 
-      icon: IconBrandGoogle, 
-      label: t('navigation.googleIOExtended.title'), 
+    {
+      icon: IconBrandGoogle,
+      label: t('navigation.googleIOExtended.title'),
       href: '/annual_activity/google_io_extended',
       isActive: isActive('/annual_activity/google_io_extended')
     },
-    { 
-      icon: IconCloud, 
-      label: t('navigation.cloudStudyJam.title'), 
+    {
+      icon: IconCloud,
+      label: t('navigation.cloudStudyJam.title'),
       href: '/annual_activity/cloud_study_jam',
       isActive: isActive('/annual_activity/cloud_study_jam')
     },
-    { 
-      icon: IconRobot, 
-      label: t('navigation.buildWithAi.title'), 
-      href: '/annual_activity/build_with_ai',
-      isActive: isActive('/annual_activity/build_with_ai')
-    },
-    { 
-      icon: IconCode, 
-      label: t('navigation.devfest.title'), 
+    {
+      icon: IconCode,
+      label: t('navigation.devfest.title'),
       href: '/annual_activity/devfest',
       isActive: isActive('/annual_activity/devfest')
     }

--- a/src/entities/anaual_activity/index.ts
+++ b/src/entities/anaual_activity/index.ts
@@ -1,24 +1,10 @@
 export const activityMeta = {
-    international_womens_day: {
-      bevytagId: "30",
-      backgroundUrl: "/event/international-womans-day/bg.png",
-      iconUrl: "/event/international-womans-day/logo.png",
-      animationUrl: "/event/international-womans-day/main.png",
-      url: "https://developers.google.com/womentechmakers/initiatives/iwd",
-    },
     google_io_extended: {
       bevytagId: "24",
       backgroundUrl: "/event/io-extends/banner.svg",
       iconUrl: "/event/io-extends/logo-white.svg",
       animationUrl: "/event/io-extends/giphy.gif",
       url: "https://gdg.community.dev/ioextended/",
-    },
-    build_with_ai: {
-      bevytagId: "73",
-      backgroundUrl: "/event/build-with-ai/banner.jpg",
-      iconUrl: "/event/build-with-ai/logo.png",
-      animationUrl: "/event/build-with-ai/minilogo.png",
-      url: "https://ai.google/build/",
     },
     cloud_study_jam: {
       bevytagId: "23",

--- a/src/i18n/locales/en/activity.ts
+++ b/src/i18n/locales/en/activity.ts
@@ -1,8 +1,4 @@
 export const activity = {
-  international_womens_day: {
-    title: "International Women's Day",
-    description: "International Women's Day (IWD) is the biggest annual event for Women Techmakers, where ambassadors around the world host activities throughout March and April to celebrate this moment. From large summits to small private gatherings, IWD is also a way for us to support our mission to build a world where all women can thrive in tech.",
-  },
   google_io_extended: {
     title: "Google I/O Extended",
     description: "Google I/O connects developers from around the world for thoughtful discussions, hands-on learning with Google experts, and an early look at Google's latest developer products. After the main event, local developer communities come together at I/O Extended events to discuss the latest technologies, host Q&As, and interact with other developers.",
@@ -14,9 +10,5 @@ export const activity = {
   devfest: {
     title: "DevFest",
     description: "DevFests are local tech conferences hosted by Google Developer Groups (GDGs) worldwide. Local organizers plan the event according to the needs of the community, leading participants to collaborate and innovate using Google-related technologies, including its open-source technologies and development tools, through hands-on experiences and expert tech talks.",
-  },
-  build_with_ai: {
-    title: "Build with AI",
-    description: "An event for developers of all skill levels to learn and build with Google's latest AI technologies. Explore generative AI through hands-on workshops and talks from Google experts.",
   },
 } as const; 

--- a/src/i18n/locales/en/metadata.ts
+++ b/src/i18n/locales/en/metadata.ts
@@ -8,10 +8,6 @@ export const metadata = {
         "description": "Recent activities of Google Developer Groups Taiwan"
     },
     "annual_activity":{
-        "international_womens_day":{
-            "title": "International Women's Day | Google Developer Groups Taiwan",
-            "description": "International Women's Day (IWD) is the largest annual event of Women Techmakers. Ambassadors host events around the world during March and April to celebrate this moment. From large summits to small private gatherings, IWD is also how we support our mission: to build a world where all women can thrive in technology."
-        },
         "google_io_extended":{
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O brings together developers from around the world for in-depth discussions, hands-on learning with Google experts, and early access to the latest Google developer products. After the main event, local communities continue to share technology, host Q&As, and interact with other developers through I/O Extended events."
@@ -24,10 +20,6 @@ export const metadata = {
             "title": "DevFest | Google Developer Groups Taiwan",
             "description": "DevFests are local tech conferences hosted by Google Developer Groups (GDG) worldwide. Local organizers plan events based on community needs, from hands-on experiences to expert tech talks, leading participants to collaborate and innovate using Google open source technologies and development tools."
         },
-        "build_with_ai": {
-            "title": "Build with AI | Google Developer Groups Taiwan",
-            "description": "An event for developers of all skill levels to learn and build with Google's latest AI technologies. Explore generative AI through hands-on workshops and talks from Google experts."
-        }
     },
     "chapters":{
         "title": "All GDG Chapters in Taiwan | Google Developer Groups Taiwan",

--- a/src/i18n/locales/en/navigation.ts
+++ b/src/i18n/locales/en/navigation.ts
@@ -3,10 +3,6 @@ export const navigation = {
     recentActivities: "Recent Activities",
     annualActivities: "Annual Activities",
     chapters: "Explore by region",
-    internationalWomensDay: {
-        title: "International Women's Day",
-        description: "International Women's Day is the largest annual event for Women Techmakers"
-    },
     googleIOExtended: {
         title: "Google I/O Extended",
         description: "Discussing the latest technologies, hosting Q&A sessions, and interacting with other developers."
@@ -18,9 +14,5 @@ export const navigation = {
     devfest: {
         title: "DevFest",
         description: "Local technical conferences hosted by Google Developer Groups (GDG) worldwide."
-    },
-    buildWithAi: {
-        title: "Build with AI",
-        description: "An event for developers of all skill levels to learn and build with Google's latest AI technologies."
     }
 }

--- a/src/i18n/locales/ja/activity.ts
+++ b/src/i18n/locales/ja/activity.ts
@@ -1,8 +1,4 @@
 export const activity = {
-  international_womens_day: {
-    title: "国際女性デー",
-    description: "国際女性デー（IWD）は、Women Techmakersの最大の年次イベントであり、世界中のアンバサダーが3月と4月を通じてこの瞬間を祝うために活動を開催します。大規模なサミットから小規模なプライベート集会まで、IWDはまた、すべての女性がテクノロジーで繁栄できる世界を構築するという私たちの使命をサポートする方法でもあります。"
-  },
   google_io_extended: {
     title: "Google I/O エクステンデッド",
     description: "Google I/Oは、世界中の開発者がGoogleの専門家とともに深い議論を行い、ハンズオンで学び、Googleの最新の開発者製品を早期に体験できるイベントです。メインイベントの後も、ローカルの開発者コミュニティがI/Oエクステンデッドイベントに集まり、最新技術について議論し、Q&Aを開催し、他の開発者と交流します。"
@@ -14,9 +10,5 @@ export const activity = {
   devfest: {
     title: "DevFest",
     description: "DevFestsは、世界中のGoogle Developer Groups（GDG）が主催する地域の技術カンファレンスです。地域の主催者がコミュニティのニーズに合わせてイベントを企画し、実践的な体験から専門家による技術講演まで、参加者がGoogle関連の技術（オープンソース技術や開発ツールを含む）を使って協力し、革新することを導きます。",
-  },
-  build_with_ai: {
-    title: "Build with AI",
-    description: "あらゆるスキルレベルの開発者が Google の最新 AI 技術を学び、構築するためのイベントです。ハンズオンワークショップや Google の専門家による講演を通じて、生成 AI を探求します。",
   },
 } as const; 

--- a/src/i18n/locales/ja/metadata.ts
+++ b/src/i18n/locales/ja/metadata.ts
@@ -8,10 +8,6 @@ export const metadata = {
         "description": "Google Developer Groups Taiwanの最近の活動"
     },
     "annual_activity":{
-        "international_womens_day":{
-            "title": "国際女性デー | Google Developer Groups Taiwan",
-            "description": "国際女性デー（IWD）はWomen Techmakersの最大の年次イベントです。アンバサダーたちは3月と4月に世界中でイベントを開催し、この瞬間を祝います。大規模なサミットから小規模なプライベート集会まで、IWDはすべての女性がテクノロジー分野で活躍できる世界を築くという私たちのミッションを支援するものでもあります。"
-        },
         "google_io_extended":{
             "title": "Google I/O エクステンデッド | Google Developer Groups Taiwan",
             "description": "Google I/Oは、世界中の開発者が集まり、Googleの専門家と共に実践的な学習やディスカッションを行い、Googleの最新開発者プロダクトをいち早く体験できるイベントです。メインイベント終了後、各地のコミュニティはI/O Extendedイベントを通じて技術交流やQ&A、他の開発者との交流を続けます。"
@@ -24,10 +20,6 @@ export const metadata = {
             "title": "DevFest | Google Developer Groups Taiwan",
             "description": "DevFestは、世界中のGoogle Developer Groups（GDG）が主催する地域技術カンファレンスです。各地の主催者がコミュニティのニーズに応じて企画し、ハンズオン体験から専門家による技術講演まで、Googleのオープンソース技術や開発ツールを使って参加者同士が協力し、イノベーションを生み出します。"
         },
-        "build_with_ai": {
-            "title": "Build with AI | Google Developer Groups Taiwan",
-            "description": "あらゆるスキルレベルの開発者が Google の最新 AI 技術を学び、構築するためのイベントです。ハンズオンワークショップや Google の専門家による講演を通じて、生成 AI を探求します。"
-        }
     },
     "chapters":{
         "title": "台湾の全GDG支部 | Google Developer Groups Taiwan",

--- a/src/i18n/locales/ja/navigation.ts
+++ b/src/i18n/locales/ja/navigation.ts
@@ -3,10 +3,6 @@ export const navigation = {
     recentActivities: "最近の活動",
     annualActivities: "年次活動",
     chapters: "地域で探す",
-    internationalWomensDay: {
-        title: "国際女性デー",
-        description: "国際女性デーは、Women Techmakersの最大の年次イベントです。"
-    },
     googleIOExtended: {
         title: "Google I/O エクステンデッド",
         description: "最新技術について議論し、Q&Aセッションを開催し、他の開発者と交流します。"
@@ -18,9 +14,5 @@ export const navigation = {
     devfest: {
         title: "DevFest",
         description: "世界中のGoogle Developer Groups（GDG）が主催するローカル技術カンファレンスです。"
-    },
-    buildWithAi: {
-        title: "Build with AI",
-        description: "あらゆるスキルレベルの開発者がGoogleの最新AI技術を学び、構築するためのイベントです。"
     }
 }

--- a/src/i18n/locales/ko/activity.ts
+++ b/src/i18n/locales/ko/activity.ts
@@ -1,8 +1,4 @@
 export const activity = {
-  international_womens_day: {
-    title: "국제 여성의 날",
-    description: "국제 여성의 날 (IWD)은 Women Techmakers의 가장 큰 연례 행사로, 대사들이 3월과 4월 동안 전 세계에서 행사를 개최하여 이 순간을 기념합니다. 대규모 정상 회담에서 소규모 개인 모임에 이르기까지, IWD는 모든 여성이 기술 분야에서 번영할 수 있는 세상을 구축하는 우리의 사명을 지원합니다.",
-  },
   google_io_extended: {
     title: "Google I/O 확장 행사",
     description: "Google I/O는 전 세계의 개발자를 모아 심도 있는 토론을 하고, Google 전문가와 함께 실습하며, Google의 최신 개발자 제품을 미리 체험할 수 있는 기회를 제공합니다. 주요 행사가 끝난 후, 지역 커뮤니티는 I/O Extended 행사를 통해 기술을 계속 공유하고, Q&A를 주최하며 다른 개발자와 상호 작용합니다.",
@@ -14,9 +10,5 @@ export const activity = {
   devfest: {
     title: "데브페스트",
     description: "데브페스트(DevFests)는 전 세계 Google 개발자 그룹(GDG)이 주최하는 지역 기술 컨퍼런스입니다. 지역 주최자는 커뮤니티의 필요에 따라 행사를 기획하며, 실습 경험부터 전문가 기술 강연에 이르기까지 참가자들이 Google 관련 기술(오픈 소스 기술 및 개발 도구 포함)을 사용하여 협력하고 혁신하도록 이끌어줍니다.",
-  },
-  build_with_ai: {
-    title: "Build with AI",
-    description: "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다. 핸즈온 워크숍과 Google 전문가의 강연을 통해 생성형 AI를 탐색해 보세요.",
   },
 } as const; 

--- a/src/i18n/locales/ko/metadata.ts
+++ b/src/i18n/locales/ko/metadata.ts
@@ -8,10 +8,6 @@ export const metadata = {
         "description": "Google Developer Groups Taiwan의 최근 활동"
     },
     "annual_activity": {
-        "international_womens_day": {
-            "title": "국제 여성의 날 | Google Developer Groups Taiwan",
-            "description": "국제 여성의 날(IWD)은 Women Techmakers의 가장 큰 연례 행사입니다. 앰배서더들은 3월과 4월에 전 세계에서 행사를 개최하여 이 순간을 기념합니다. 대규모 서밋부터 소규모 프라이빗 모임까지, IWD는 모든 여성이 기술 분야에서 번영할 수 있는 세상을 만드는 우리의 미션을 지원하는 방법이기도 합니다."
-        },
         "google_io_extended": {
             "title": "Google I/O 확장 행사 | Google Developer Groups Taiwan",
             "description": "Google I/O는 전 세계의 개발자들이 모여 심도 있는 토론을 하고, Google 전문가와 함께 실습 학습을 하며, Google의 최신 개발자 제품을 가장 먼저 체험할 수 있는 행사입니다. 메인 이벤트가 끝난 후, 현지 커뮤니티는 I/O Extended 행사를 통해 기술을 공유하고, Q&A를 진행하며, 다른 개발자들과 교류를 이어갑니다."
@@ -24,10 +20,6 @@ export const metadata = {
             "title": "DevFest | Google Developer Groups Taiwan",
             "description": "DevFest는 전 세계 Google Developer Groups(GDG)가 주최하는 지역 기술 컨퍼런스입니다. 현지 주최자는 커뮤니티의 요구에 따라 행사를 기획하며, 실습 경험부터 전문가 기술 강연까지, Google 오픈소스 기술과 개발 도구를 사용해 참가자들이 협력하고 혁신할 수 있도록 이끕니다."
         },
-        "build_with_ai": {
-            "title": "Build with AI | Google Developer Groups Taiwan",
-            "description": "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다. 핸즈온 워크숍과 Google 전문가의 강연을 통해 생성형 AI를 탐색해 보세요."
-        }
     },
     "chapters": {
         "title": "대만의 모든 GDG 지부 | Google Developer Groups Taiwan",

--- a/src/i18n/locales/ko/navigation.ts
+++ b/src/i18n/locales/ko/navigation.ts
@@ -3,10 +3,6 @@ export const navigation = {
     recentActivities: "최신 활동",
     annualActivities: "연례 활동",
     chapters: "지역별로 탐색하기",
-    internationalWomensDay: {
-        title: "국제 여성의 날",
-        description: "국제 여성의 날은 Women Techmakers의 가장 큰 연례 행사입니다."
-    },
     googleIOExtended: {
         title: "Google I/O 확장 행사",
         description: "최신 기술에 대해 논의하고, 내용을 요약하며, Q&A 세션을 주최하고 다른 기술 애호가를 만납니다."
@@ -18,9 +14,5 @@ export const navigation = {
     devfest: {
         title: "DevFest",
         description: "전 세계 Google Developer Group (GDG)이 주최하는 지역 기술 세미나입니다."
-    },
-    buildWithAi: {
-        title: "Build with AI",
-        description: "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다."
     }
 }

--- a/src/i18n/locales/zh-CN/activity.ts
+++ b/src/i18n/locales/zh-CN/activity.ts
@@ -1,8 +1,4 @@
 export const activity = {
-  international_womens_day: {
-    title: "国际妇女节",
-    description: "国际妇女节 (IWD) 是 Women Techmakers 最大的年度活动，大使们在 3 月和 4 月期间在世界各地举办活动以庆祝这一时刻。从大型峰会到小型私密聚会，IWD 也是我们支持使命：构建一个所有女性都能在科技领域繁荣茁壮的世界。",
-  },
   google_io_extended: {
     title: "Google I/O 延伸活动",
     description: "Google I/O 将来自全球的开发者聚集在一起，进行深入讨论、与 Google 专家实作学习，并抢先体验 Google 最新开发者产品。主赛事结束后，当地社群透过 I/O Extended 活动继续交流技术、主持问答并与其他开发者互动。",
@@ -14,9 +10,5 @@ export const activity = {
   devfest: {
     title: "DevFest",
     description: "DevFests 是由全球 Google Developer Groups (GDG) 主办的在地技术研讨会。当地主办方依据社群需求策划，从实作体验到专家技术讲座，带领参与者使用 Google 相关技术，包括其开源技术与开发工具协作创新。",
-  },
-  build_with_ai: {
-    title: "Build with AI",
-    description: "这是一个为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。通过实践工作坊和 Google 专家的演讲，探索生成式 AI。",
   },
 } as const; 

--- a/src/i18n/locales/zh-CN/metadata.ts
+++ b/src/i18n/locales/zh-CN/metadata.ts
@@ -8,10 +8,6 @@ export const metadata = {
         "description": "Google Developer Groups Taiwan 的近期活动"
     },
     "annual_activity":{
-        "international_womens_day":{
-            "title": "国际妇女节 ｜ Google Developer Groups Taiwan",
-            "description": "国际妇女节 (IWD) 是 Women Techmakers 最大的年度活动，大使们在 3 月和 4 月期间在世界各地举办活动以庆祝这一时刻。从大型峰会到小型私密聚会，IWD 也是我们支持使命：构建一个所有女性都能在科技领域繁荣发展的世界。"
-        },
         "google_io_extended":{
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O 将来自全球的开发者聚集在一起，进行深入讨论、与 Google 专家实作学习，并抢先体验 Google 最新开发者产品。主赛事结束后，当地社区通过 I/O Extended 活动继续交流技术、主持问答并与其他开发者互动。"
@@ -24,10 +20,6 @@ export const metadata = {
             "title": "DevFest | Google Developer Groups Taiwan",
             "description": "DevFests 是由全球 Google Developer Groups (GDG) 主办的本地技术研讨会。本地主办方依据社区需求策划，从实作体验到专家技术讲座，带领参与者使用 Google 开源技术与开发工具协作创新。"
         },
-        "build_with_ai": {
-            "title": "Build with AI | Google Developer Groups Taiwan",
-            "description": "这是一个为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。通过实践工作坊和 Google 专家的演讲，探索生成式 AI。"
-        }
     },
     "chapters":{
         "title": "全台 GDG 社群 | Google Developer Groups Taiwan",

--- a/src/i18n/locales/zh-CN/navigation.ts
+++ b/src/i18n/locales/zh-CN/navigation.ts
@@ -3,10 +3,6 @@ export const navigation = {
     recentActivities: "最新活动",
     annualActivities: "年度活动",
     chapters: "探索地区",
-    internationalWomensDay: {
-        title: "国际妇女节",
-        description: "国际妇女节是 Women Techmakers 最大的年度活动"
-    },
     googleIOExtended: {
         title: "Google I/O 延伸活动",
         description: "讨论最新的新技术、总结内容、主持问答环节并会见其他技术爱好者。"
@@ -18,9 +14,5 @@ export const navigation = {
     devfest: {
         title: "DevFest",
         description: "是由全球 Google Developer Group (GDG) 主持的当地技术研讨会。"
-    },
-    buildWithAi: {
-        title: "Build with AI",
-        description: "为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。"
     }
 }

--- a/src/i18n/locales/zh/activity.ts
+++ b/src/i18n/locales/zh/activity.ts
@@ -1,8 +1,4 @@
 export const activity = {
-  international_womens_day: {
-    title: "國際婦女節",
-    description: "國際婦女節 (IWD) 是 Women Techmakers 最大的年度活動，大使們在 3 月和 4 月期間在世界各地舉辦活動以慶祝這一時刻。從大型峰會到小型私密聚會，IWD 也是我們支持使命：建構一個所有女性都能在科技領域繁榮茁壯的世界。",
-  },
   google_io_extended: {
     title: "Google I/O 延伸活動",
     description: "Google I/O 將來自全球的開發者聚集在一起，進行深入討論、與 Google 專家實作學習，並搶先體驗 Google 最新開發者產品。主賽事結束後，當地社群透過 I/O Extended 活動繼續交流技術、主持問答並與其他開發者互動。",
@@ -14,9 +10,5 @@ export const activity = {
   devfest: {
     title: "DevFest",
     description: "DevFests 是由全球 Google Developer Groups (GDG) 主辦的在地技術研討會。當地主辦方依據社群需求策劃，從實作體驗到專家技術講座，帶領參與者使用 Google 相關技術，包括其開源技術與開發工具協作創新。",
-  },
-  build_with_ai: {
-    title: "Build with AI",
-    description: "這是一個為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。透過實作工作坊和 Google 專家的演講，探索生成式 AI。",
   },
 } as const; 

--- a/src/i18n/locales/zh/metadata.ts
+++ b/src/i18n/locales/zh/metadata.ts
@@ -8,10 +8,6 @@ export const metadata = {
         "description": "Google Developer Groups Taiwan 的近期活動"
     },
     "annual_activity":{
-        "international_womens_day":{
-            "title": "國際婦女節 ｜ Google Developer Groups Taiwan",
-            "description": "國際婦女節 (IWD) 是 Women Techmakers 最大的年度活動，大使們在 3 月和 4 月期間在世界各地舉辦活動以慶祝這一時刻。從大型峰會到小型私密聚會，IWD 也是我們支持使命：建構一個所有女性都能在科技領域繁榮茁壯的世界。"
-        },
         "google_io_extended":{
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O 將來自全球的開發者聚集在一起，進行深入討論、與 Google 專家實作學習，並搶先體驗 Google 最新開發者產品。主賽事結束後，當地社群透過 I/O Extended 活動繼續交流技術、主持問答並與其他開發者互動。",
@@ -24,10 +20,6 @@ export const metadata = {
             "title": "DevFest | Google Developer Groups Taiwan",
             "description": "DevFests 是由全球 Google Developer Groups (GDG) 主辦的在地技術研討會。當地主辦方依據社群需求策劃，從實作體驗到專家技術講座，帶領參與者使用 Google 開源技術與開發工具協作創新。"
         },
-        "build_with_ai": {
-            "title": "Build with AI | Google Developer Groups Taiwan",
-            "description": "這是一個為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。透過實作工作坊和 Google 專家的演講，探索生成式 AI。"
-        }
     },
     "chapters":{
         "title": "全台 GDG 社群 | Google Developer Groups Taiwan",

--- a/src/i18n/locales/zh/navigation.ts
+++ b/src/i18n/locales/zh/navigation.ts
@@ -3,10 +3,6 @@ export const navigation = {
     recentActivities: "最新活動",
     annualActivities: "年度活動",
     chapters: "探索區域",
-    internationalWomensDay: {
-        title: "國際婦女節",
-        description: "國際婦女節是 Women Techmakers 最大的年度活動"
-    },
     googleIOExtended: {
         title: "Google I/O 延伸活動",
         description: "討論最新的新技術、總結內容、主持問答環節並會見其他技術愛好者。"
@@ -18,9 +14,5 @@ export const navigation = {
     devfest: {
         title: "DevFest",
         description: "是由全球 Google Developer Group (GDG) 主持的當地技術研討會。"
-    },
-    buildWithAi: {
-        title: "Build with AI",
-        description: "為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。"
     }
 }


### PR DESCRIPTION
## Summary

- Removes `international_womens_day` and `build_with_ai` from nav menus (desktop + mobile)
- Cleans up all i18n strings across 5 locales (en, zh, zh-CN, ja, ko) — activity, metadata, and navigation files
- Removes unused icon imports (`IconWomanFilled`, `IconRobot`) from mobile menu

Completes the cleanup started in 44bf9b2, which only removed the entity metadata entries.

## Test plan

- [ ] Verify Annual Activities dropdown no longer shows International Women's Day or Build with AI
- [ ] Check mobile menu accordion matches desktop nav
- [ ] Confirm no broken translation keys in all 5 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)