### PR TITLE
feat(activity): replace cloud_study_jam with build_with_ai

### DIFF
--- a/src/components/site-desktop-menu.tsx
+++ b/src/components/site-desktop-menu.tsx
@@ -31,8 +31,8 @@ export function SiteDesktopMenu() {
           <ListItem href="/annual_activity/google_io_extended" title={t('navigation.googleIOExtended.title')}>
             {t('navigation.googleIOExtended.description')}
           </ListItem>
-          <ListItem href="/annual_activity/cloud_study_jam" title={t('navigation.cloudStudyJam.title')}>
-            {t('navigation.cloudStudyJam.description')}
+          <ListItem href="/annual_activity/build_with_ai" title={t('navigation.buildWithAi.title')}>
+            {t('navigation.buildWithAi.description')}
           </ListItem>
           <ListItem href="/annual_activity/devfest" title={t('navigation.devfest.title')}>
             {t('navigation.devfest.description')}

--- a/src/components/site-mobile-menu.tsx
+++ b/src/components/site-mobile-menu.tsx
@@ -9,7 +9,7 @@ import { DrawerContent } from './ui/drawer';
 import { LanguageToggle } from './language-toggle';
 import { ModeToggle } from './model-toggle';
 import { useState, useEffect } from 'react';
-import { IconBrandGoogle, IconCalendarEvent, IconCode, IconCloud, IconMapPin, IconHome } from '@tabler/icons-react';
+import { IconBrandGoogle, IconCalendarEvent, IconCode, IconMapPin, IconHome, IconRobot } from '@tabler/icons-react';
 
 export function SiteMobileMenu() {
   const { t } = useTranslation();
@@ -42,10 +42,10 @@ export function SiteMobileMenu() {
       isActive: isActive('/annual_activity/google_io_extended')
     },
     {
-      icon: IconCloud,
-      label: t('navigation.cloudStudyJam.title'),
-      href: '/annual_activity/cloud_study_jam',
-      isActive: isActive('/annual_activity/cloud_study_jam')
+      icon: IconRobot,
+      label: t('navigation.buildWithAi.title'),
+      href: '/annual_activity/build_with_ai',
+      isActive: isActive('/annual_activity/build_with_ai')
     },
     {
       icon: IconCode,

--- a/src/entities/anaual_activity/index.ts
+++ b/src/entities/anaual_activity/index.ts
@@ -6,12 +6,12 @@ export const activityMeta = {
       animationUrl: "/event/io-extends/giphy.gif",
       url: "https://gdg.community.dev/ioextended/",
     },
-    cloud_study_jam: {
-      bevytagId: "23",
-      backgroundUrl: "/event/cloud-study-jam/banner.jpg",
-      iconUrl: "/event/cloud-study-jam/logo.svg",
-      animationUrl: "/event/cloud-study-jam/cloud_animation.gif",
-      url: "https://events.withgoogle.com/cloud-studyjam/",
+    build_with_ai: {
+      bevytagId: "73",
+      backgroundUrl: "/event/build-with-ai/banner.jpg",
+      iconUrl: "/event/build-with-ai/logo.png",
+      animationUrl: "/event/build-with-ai/minilogo.png",
+      url: "https://ai.google/build/",
     },
     devfest: {
       bevytagId: "21",

--- a/src/i18n/locales/en/activity.ts
+++ b/src/i18n/locales/en/activity.ts
@@ -3,9 +3,9 @@ export const activity = {
     title: "Google I/O Extended",
     description: "Google I/O connects developers from around the world for thoughtful discussions, hands-on learning with Google experts, and an early look at Google's latest developer products. After the main event, local developer communities come together at I/O Extended events to discuss the latest technologies, host Q&As, and interact with other developers.",
   },
-  cloud_study_jam: {
-    title: "Cloud Study Jams",
-    description: "From containerized apps to spinning up virtual machines, Study Jams can be tailored to specific cloud topics and skill levels. Whether you're a beginner developer or looking to dive deep into machine learning, BigQuery, certifications, or Kubernetes, there's always a path for you. You'll learn the fundamentals of Google Cloud's tools and capabilities through free, hands-on labs.",
+  build_with_ai: {
+    title: "Build with AI",
+    description: "An event for developers of all skill levels to learn and build with Google's latest AI technologies. Explore generative AI through hands-on workshops and talks from Google experts.",
   },
   devfest: {
     title: "DevFest",

--- a/src/i18n/locales/en/metadata.ts
+++ b/src/i18n/locales/en/metadata.ts
@@ -12,9 +12,9 @@ export const metadata = {
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O brings together developers from around the world for in-depth discussions, hands-on learning with Google experts, and early access to the latest Google developer products. After the main event, local communities continue to share technology, host Q&As, and interact with other developers through I/O Extended events."
         },
-        "cloud_study_jam":{
-            "title": "Cloud Study Jam | Google Developer Groups Taiwan",
-            "description": "From containerized applications to creating virtual machines, Study Jams can be customized by topic and skill level. Whether it's cloud basics or deep dives into machine learning, BigQuery, certification, or Kubernetes, you can learn Google Cloud's core tools and features through free hands-on labs."
+        "build_with_ai": {
+            "title": "Build with AI | Google Developer Groups Taiwan",
+            "description": "An event for developers of all skill levels to learn and build with Google's latest AI technologies. Explore generative AI through hands-on workshops and talks from Google experts."
         },
         "devfest":{
             "title": "DevFest | Google Developer Groups Taiwan",

--- a/src/i18n/locales/en/navigation.ts
+++ b/src/i18n/locales/en/navigation.ts
@@ -7,9 +7,9 @@ export const navigation = {
         title: "Google I/O Extended",
         description: "Discussing the latest technologies, hosting Q&A sessions, and interacting with other developers."
     },
-    cloudStudyJam: {
-        title: "Cloud Study Jam",
-        description: "From containerized applications to creating virtual machines, Study Jams can be customized for specific cloud themes and skill levels."
+    buildWithAi: {
+        title: "Build with AI",
+        description: "An event for developers of all skill levels to learn and build with Google's latest AI technologies."
     },
     devfest: {
         title: "DevFest",

--- a/src/i18n/locales/ja/activity.ts
+++ b/src/i18n/locales/ja/activity.ts
@@ -3,9 +3,9 @@ export const activity = {
     title: "Google I/O エクステンデッド",
     description: "Google I/Oは、世界中の開発者がGoogleの専門家とともに深い議論を行い、ハンズオンで学び、Googleの最新の開発者製品を早期に体験できるイベントです。メインイベントの後も、ローカルの開発者コミュニティがI/Oエクステンデッドイベントに集まり、最新技術について議論し、Q&Aを開催し、他の開発者と交流します。"
   },
-  cloud_study_jam: {
-    title: "クラウドスタディジャム",
-    description: "コンテナ化されたアプリから仮想マシンの立ち上げまで、スタディジャムは特定のクラウドトピックとスキルレベルに合わせてカスタマイズできます。初心者の開発者であっても、機械学習、BigQuery、認定、Kubernetesに深く入り込むことを望んでいる場合でも、常にあなたのための道があります。Google Cloudのツールと機能の基本を無料のハンズオンラボを通じて学びます。"
+  build_with_ai: {
+    title: "Build with AI",
+    description: "あらゆるスキルレベルの開発者が Google の最新 AI 技術を学び、構築するためのイベントです。ハンズオンワークショップや Google の専門家による講演を通じて、生成 AI を探求します。",
   },
   devfest: {
     title: "DevFest",

--- a/src/i18n/locales/ja/metadata.ts
+++ b/src/i18n/locales/ja/metadata.ts
@@ -12,9 +12,9 @@ export const metadata = {
             "title": "Google I/O エクステンデッド | Google Developer Groups Taiwan",
             "description": "Google I/Oは、世界中の開発者が集まり、Googleの専門家と共に実践的な学習やディスカッションを行い、Googleの最新開発者プロダクトをいち早く体験できるイベントです。メインイベント終了後、各地のコミュニティはI/O Extendedイベントを通じて技術交流やQ&A、他の開発者との交流を続けます。"
         },
-        "cloud_study_jam":{
-            "title": "クラウドスタディジャム | Google Developer Groups Taiwan",
-            "description": "コンテナ化アプリケーションから仮想マシンの作成まで、Study Jamはテーマやスキルレベルに応じてカスタマイズできます。クラウドの基礎から機械学習、BigQuery、認定、Kubernetesの深掘りまで、Google Cloudの主要ツールと機能を無料のハンズオンラボで学ぶことができます。"
+        "build_with_ai": {
+            "title": "Build with AI | Google Developer Groups Taiwan",
+            "description": "あらゆるスキルレベルの開発者が Google の最新 AI 技術を学び、構築するためのイベントです。ハンズオンワークショップや Google の専門家による講演を通じて、生成 AI を探求します。"
         },
         "devfest":{
             "title": "DevFest | Google Developer Groups Taiwan",

--- a/src/i18n/locales/ja/navigation.ts
+++ b/src/i18n/locales/ja/navigation.ts
@@ -7,9 +7,9 @@ export const navigation = {
         title: "Google I/O エクステンデッド",
         description: "最新技術について議論し、Q&Aセッションを開催し、他の開発者と交流します。"
     },
-    cloudStudyJam: {
-        title: "クラウドスタディジャム",
-        description: "コンテナ化されたアプリケーションから仮想マシンの作成まで、スタディジャムは特定のクラウドテーマとスキルレベルに合わせてカスタマイズできます。"
+    buildWithAi: {
+        title: "Build with AI",
+        description: "あらゆるスキルレベルの開発者がGoogleの最新AI技術を学び、構築するためのイベントです。"
     },
     devfest: {
         title: "DevFest",

--- a/src/i18n/locales/ko/activity.ts
+++ b/src/i18n/locales/ko/activity.ts
@@ -3,9 +3,9 @@ export const activity = {
     title: "Google I/O 확장 행사",
     description: "Google I/O는 전 세계의 개발자를 모아 심도 있는 토론을 하고, Google 전문가와 함께 실습하며, Google의 최신 개발자 제품을 미리 체험할 수 있는 기회를 제공합니다. 주요 행사가 끝난 후, 지역 커뮤니티는 I/O Extended 행사를 통해 기술을 계속 공유하고, Q&A를 주최하며 다른 개발자와 상호 작용합니다.",
   },
-  cloud_study_jam: {
-    title: "클라우드 스터디 잼",
-    description: "컨테이너화된 애플리케이션에서 가상 머신 생성에 이르기까지, Study Jams는 주제와 기술 수준에 따라 사용자 정의할 수 있습니다. 클라우드 기초 입문부터 머신러닝, BigQuery, 인증 또는 Kubernetes에 대한 심층 탐구까지, 무료 실습 실험실을 통해 Google Cloud의 핵심 도구와 기능을 배울 수 있습니다.",
+  build_with_ai: {
+    title: "Build with AI",
+    description: "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다. 핸즈온 워크숍과 Google 전문가의 강연을 통해 생성형 AI를 탐색해 보세요.",
   },
   devfest: {
     title: "데브페스트",

--- a/src/i18n/locales/ko/metadata.ts
+++ b/src/i18n/locales/ko/metadata.ts
@@ -12,9 +12,9 @@ export const metadata = {
             "title": "Google I/O 확장 행사 | Google Developer Groups Taiwan",
             "description": "Google I/O는 전 세계의 개발자들이 모여 심도 있는 토론을 하고, Google 전문가와 함께 실습 학습을 하며, Google의 최신 개발자 제품을 가장 먼저 체험할 수 있는 행사입니다. 메인 이벤트가 끝난 후, 현지 커뮤니티는 I/O Extended 행사를 통해 기술을 공유하고, Q&A를 진행하며, 다른 개발자들과 교류를 이어갑니다."
         },
-        "cloud_study_jam": {
-            "title": "클라우드 스터디 잼 | Google Developer Groups Taiwan",
-            "description": "컨테이너화된 애플리케이션부터 가상 머신 생성까지, Study Jam은 주제와 기술 수준에 따라 맞춤화할 수 있습니다. 클라우드 기초 입문부터 머신러닝, BigQuery, 인증, Kubernetes의 심화 학습까지, Google Cloud의 핵심 도구와 기능을 무료 실습 랩을 통해 배울 수 있습니다."
+        "build_with_ai": {
+            "title": "Build with AI | Google Developer Groups Taiwan",
+            "description": "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다. 핸즈온 워크숍과 Google 전문가의 강연을 통해 생성형 AI를 탐색해 보세요."
         },
         "devfest": {
             "title": "DevFest | Google Developer Groups Taiwan",

--- a/src/i18n/locales/ko/navigation.ts
+++ b/src/i18n/locales/ko/navigation.ts
@@ -7,9 +7,9 @@ export const navigation = {
         title: "Google I/O 확장 행사",
         description: "최신 기술에 대해 논의하고, 내용을 요약하며, Q&A 세션을 주최하고 다른 기술 애호가를 만납니다."
     },
-    cloudStudyJam: {
-        title: "클라우드 스터디 잼",
-        description: "컨테이너화된 애플리케이션에서 가상 머신 생성에 이르기까지, Study Jams는 특정 클라우드 주제와 기술 수준에 맞게 사용자 정의할 수 있습니다."
+    buildWithAi: {
+        title: "Build with AI",
+        description: "모든 기술 수준의 개발자들이 Google의 최신 AI 기술을 배우고 구축할 수 있는 이벤트입니다."
     },
     devfest: {
         title: "DevFest",

--- a/src/i18n/locales/zh-CN/activity.ts
+++ b/src/i18n/locales/zh-CN/activity.ts
@@ -3,9 +3,9 @@ export const activity = {
     title: "Google I/O 延伸活动",
     description: "Google I/O 将来自全球的开发者聚集在一起，进行深入讨论、与 Google 专家实作学习，并抢先体验 Google 最新开发者产品。主赛事结束后，当地社群透过 I/O Extended 活动继续交流技术、主持问答并与其他开发者互动。",
   },
-  cloud_study_jam: {
-    title: "Cloud Study Jam",
-    description: "从容器化应用到建立虚拟机，Study Jams 可根据主题与技能等级进行自订。无论是云端基础入门或深入探讨机器学习、BigQuery、认证或 Kubernetes，都能透过免费实作实验室学习 Google Cloud 的核心工具与功能。",
+  build_with_ai: {
+    title: "Build with AI",
+    description: "这是一个为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。通过实践工作坊和 Google 专家的演讲，探索生成式 AI。",
   },
   devfest: {
     title: "DevFest",

--- a/src/i18n/locales/zh-CN/metadata.ts
+++ b/src/i18n/locales/zh-CN/metadata.ts
@@ -12,9 +12,9 @@ export const metadata = {
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O 将来自全球的开发者聚集在一起，进行深入讨论、与 Google 专家实作学习，并抢先体验 Google 最新开发者产品。主赛事结束后，当地社区通过 I/O Extended 活动继续交流技术、主持问答并与其他开发者互动。"
         },
-        "cloud_study_jam":{
-            "title": "云端研习营 | Google Developer Groups Taiwan",
-            "description": "从容器化应用到建立虚拟机，Study Jams 可根据主题与技能等级进行自定义。无论是云端基础入门或深入探讨机器学习、BigQuery、认证或 Kubernetes，都能通过免费实作实验室学习 Google Cloud 的核心工具与功能。"
+        "build_with_ai": {
+            "title": "Build with AI | Google Developer Groups Taiwan",
+            "description": "这是一个为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。通过实践工作坊和 Google 专家的演讲，探索生成式 AI。"
         },
         "devfest":{
             "title": "DevFest | Google Developer Groups Taiwan",

--- a/src/i18n/locales/zh-CN/navigation.ts
+++ b/src/i18n/locales/zh-CN/navigation.ts
@@ -7,9 +7,9 @@ export const navigation = {
         title: "Google I/O 延伸活动",
         description: "讨论最新的新技术、总结内容、主持问答环节并会见其他技术爱好者。"
     },
-    cloudStudyJam: {
-        title: "云端研习营",
-        description: "从容器化应用程序到创建虚拟机，Study Jams 可以根据特定的云端主题和技能水平进行自定义。"
+    buildWithAi: {
+        title: "Build with AI",
+        description: "为各种技能水平的开发者设计的活动，旨在学习和使用 Google 最新的 AI 技术进行构建。"
     },
     devfest: {
         title: "DevFest",

--- a/src/i18n/locales/zh/activity.ts
+++ b/src/i18n/locales/zh/activity.ts
@@ -3,9 +3,9 @@ export const activity = {
     title: "Google I/O 延伸活動",
     description: "Google I/O 將來自全球的開發者聚集在一起，進行深入討論、與 Google 專家實作學習，並搶先體驗 Google 最新開發者產品。主賽事結束後，當地社群透過 I/O Extended 活動繼續交流技術、主持問答並與其他開發者互動。",
   },
-  cloud_study_jam: {
-    title: "Cloud Study Jam",
-    description: "從容器化應用到建立虛擬機，Study Jams 可根據主題與技能等級進行自訂。無論是雲端基礎入門或深入探討機器學習、BigQuery、認證或 Kubernetes，都能透過免費實作實驗室學習 Google Cloud 的核心工具與功能。",
+  build_with_ai: {
+    title: "Build with AI",
+    description: "這是一個為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。透過實作工作坊和 Google 專家的演講，探索生成式 AI。",
   },
   devfest: {
     title: "DevFest",

--- a/src/i18n/locales/zh/metadata.ts
+++ b/src/i18n/locales/zh/metadata.ts
@@ -12,9 +12,9 @@ export const metadata = {
             "title": "Google I/O Extended | Google Developer Groups Taiwan",
             "description": "Google I/O 將來自全球的開發者聚集在一起，進行深入討論、與 Google 專家實作學習，並搶先體驗 Google 最新開發者產品。主賽事結束後，當地社群透過 I/O Extended 活動繼續交流技術、主持問答並與其他開發者互動。",
         },
-        "cloud_study_jam":{
-            "title": "Cloud Study Jam | Google Developer Groups Taiwan",
-            "description": "從容器化應用到建立虛擬機，Study Jams 可根據主題與技能等級進行自訂。無論是雲端基礎入門或深入探討機器學習、BigQuery、認證或 Kubernetes，都能透過免費實作實驗室學習 Google Cloud 的核心工具與功能。",
+        "build_with_ai": {
+            "title": "Build with AI | Google Developer Groups Taiwan",
+            "description": "這是一個為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。透過實作工作坊和 Google 專家的演講，探索生成式 AI。"
         },
         "devfest":{
             "title": "DevFest | Google Developer Groups Taiwan",

--- a/src/i18n/locales/zh/navigation.ts
+++ b/src/i18n/locales/zh/navigation.ts
@@ -7,9 +7,9 @@ export const navigation = {
         title: "Google I/O 延伸活動",
         description: "討論最新的新技術、總結內容、主持問答環節並會見其他技術愛好者。"
     },
-    cloudStudyJam: {
-        title: "雲端研習營",
-        description: "從容器化應用程式到創建虛擬機，Study Jams 可以根據特定的雲端主題和技能水平進行自訂。"
+    buildWithAi: {
+        title: "Build with AI",
+        description: "為各種技能水平的開發者設計的活動，旨在學習和使用 Google 最新的 AI 技術進行建構。"
     },
     devfest: {
         title: "DevFest",


### PR DESCRIPTION
## Summary
- Cloud Study Jam is no longer an active annual activity; Build with AI takes its place in the desktop/mobile navigation menus, activity metadata (`entities/anaual_activity`), and all locale translations (en/ja/ko/zh-CN/zh).
- Based on latest `main`, which already merged the removal of `international_womens_day`/`build_with_ai` in #100 — this branch supersedes the stale `feat/remove-inactive-annual-activities` branch, which was cut before that merge.

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [ ] Manually verify `/annual_activity/build_with_ai` renders correctly and `cloud_study_jam` route/links are no longer surfaced in nav

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>